### PR TITLE
Allow variable input size

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,5 +1,6 @@
 import torch
 from torch import nn
+import torch.nn.functional as F
 
 
 class Mish(torch.nn.Module):
@@ -12,21 +13,13 @@ class Mish(torch.nn.Module):
 
 
 class Upsample(nn.Module):
-    def __init__(self, stride=2):
+    def __init__(self):
         super(Upsample, self).__init__()
-        self.stride = stride
 
-    def forward(self, x):
-        stride = self.stride
+    def forward(self, x, target_size):
         assert (x.data.dim() == 4)
-        B = x.data.size(0)
-        C = x.data.size(1)
-        H = x.data.size(2)
-        W = x.data.size(3)
-        ws = stride
-        hs = stride
-        x = x.view(B, C, H, 1, W, 1).expand(B, C, H, stride, W, stride).contiguous().view(B, C, H * stride, W * stride)
-        return x
+        _, _, H, W = target_size
+        return F.interpolate(x, size=(H, W), mode='nearest')
 
 
 class Conv_Bn_Activation(nn.Module):
@@ -283,7 +276,7 @@ class Neck(nn.Module):
         x6 = self.conv6(x5)
         x7 = self.conv7(x6)
         # UP
-        up = self.upsample1(x7)
+        up = self.upsample1(x7, downsample4.size())
         # R 85
         x8 = self.conv8(downsample4)
         # R -1 -3
@@ -297,7 +290,7 @@ class Neck(nn.Module):
         x14 = self.conv14(x13)
 
         # UP
-        up = self.upsample2(x14)
+        up = self.upsample2(x14, downsample3.size())
         # R 54
         x15 = self.conv15(downsample3)
         # R -1 -3

--- a/tool/utils.py
+++ b/tool/utils.py
@@ -421,7 +421,7 @@ def do_detect(model, img, conf_thresh, nms_thresh, use_cuda=1):
 
     list_features_numpy = []
     for feature in list_features:
-        list_features_numpy.append(feature.data.numpy())
+        list_features_numpy.append(feature.data.cpu().numpy())
 
     return post_processing(img, nms_thresh, list_features_numpy)
 


### PR DESCRIPTION
- Fully convolutional networks should be usable with arbitrary input sizes. The previous upsampling layer requires input sizes that can be divided by 2 across all five downsample stages. This was required by the upsamling layer to produce correct spatial dimensions that can be concatenated. Otherwise the spatial size is a mismatch. 

- The new upsampling layer takes care of upsamling to the correct size. It still uses nearest-neighbor as in the previous version.

- Minor: Makes sure that the features are on the cpu before converting to numpy (issue when using cuda)