### PR TITLE
修复一个使用自己的数据集时推理阶段的小bug

### DIFF
--- a/models.py
+++ b/models.py
@@ -318,15 +318,16 @@ class Neck(nn.Module):
 
 
 class Yolov4Head(nn.Module):
-    def __init__(self, output_ch, inference=False):
+    def __init__(self, n_classes, inference=False):
         super().__init__()
+        output_ch = (4 + 1 + n_classes) * 3
         self.inference = inference
 
         self.conv1 = Conv_Bn_Activation(128, 256, 3, 1, 'leaky')
         self.conv2 = Conv_Bn_Activation(256, output_ch, 1, 1, 'linear', bn=False, bias=True)
 
         self.yolo1 = YoloLayer(
-                                anchor_mask=[0, 1, 2], num_classes=80,
+                                anchor_mask=[0, 1, 2], num_classes=n_classes,
                                 anchors=[12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401],
                                 num_anchors=9, stride=8)
 
@@ -343,7 +344,7 @@ class Yolov4Head(nn.Module):
         self.conv10 = Conv_Bn_Activation(512, output_ch, 1, 1, 'linear', bn=False, bias=True)
         
         self.yolo2 = YoloLayer(
-                                anchor_mask=[3, 4, 5], num_classes=80,
+                                anchor_mask=[3, 4, 5], num_classes=n_classes,
                                 anchors=[12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401],
                                 num_anchors=9, stride=16)
 
@@ -360,7 +361,7 @@ class Yolov4Head(nn.Module):
         self.conv18 = Conv_Bn_Activation(1024, output_ch, 1, 1, 'linear', bn=False, bias=True)
         
         self.yolo3 = YoloLayer(
-                                anchor_mask=[6, 7, 8], num_classes=80,
+                                anchor_mask=[6, 7, 8], num_classes=n_classes,
                                 anchors=[12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401],
                                 num_anchors=9, stride=32)
 
@@ -408,8 +409,6 @@ class Yolov4(nn.Module):
     def __init__(self, yolov4conv137weight=None, n_classes=80, inference=False):
         super().__init__()
 
-        output_ch = (4 + 1 + n_classes) * 3
-
         # backbone
         self.down1 = DownSample1()
         self.down2 = DownSample2()
@@ -431,7 +430,7 @@ class Yolov4(nn.Module):
             _model.load_state_dict(model_dict)
         
         # head
-        self.head = Yolov4Head(output_ch, inference)
+        self.head = Yolov4Head(n_classes, inference)
 
 
     def forward(self, input):


### PR DESCRIPTION
Yolov4Head类在推理阶段使用了YoloLayer，默认传入的类别是80。使用自己的数据集训练和推理需要自行指定需要的类别数量，所以修改了一下传入参数。