### PR TITLE
Fixes Tianxiaomo/pytorch-YOLOv4#189

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -258,7 +258,7 @@ class Yolo_dataset(Dataset):
             data = line.split(" ")
             truth[data[0]] = []
             for i in data[1:]:
-                truth[data[0]].append([int(j) for j in i.split(',')])
+                truth[data[0]].append([int(float(j)) for j in i.split(',')])
 
         self.truth = truth
         self.imgs = list(self.truth.keys())

--- a/tool/darknet2pytorch.py
+++ b/tool/darknet2pytorch.py
@@ -246,15 +246,15 @@ class Darknet(nn.Module):
         conv_id = 0
         for block in blocks:
             if block['type'] == 'net':
-                prev_filters = int(block['channels'])
+                prev_filters = int(float(block['channels']))
                 continue
             elif block['type'] == 'convolutional':
                 conv_id = conv_id + 1
-                batch_normalize = int(block['batch_normalize'])
-                filters = int(block['filters'])
-                kernel_size = int(block['size'])
-                stride = int(block['stride'])
-                is_pad = int(block['pad'])
+                batch_normalize = int(float(block['batch_normalize']))
+                filters = int(float(block['filters']))
+                kernel_size = int(float(block['size']))
+                stride = int(float(block['stride']))
+                is_pad = int(float(block['pad']))
                 pad = (kernel_size - 1) // 2 if is_pad else 0
                 activation = block['activation']
                 model = nn.Sequential()


### PR DESCRIPTION
Fixes Tianxiaomo/pytorch-YOLOv4#189
`int("1.0")` results in `ValueError: invalid literal for int() with base 10:`. Changed to `int(float("1.0"))`.