### PR TITLE
Fixed an coco evaluate error while training yourself dataset

### DIFF
--- a/tool/tv_reference/coco_eval.py
+++ b/tool/tv_reference/coco_eval.py
@@ -273,6 +273,7 @@ def loadRes(self, resFile):
     elif 'bbox' in anns[0] and not anns[0]['bbox'] == []:
         res.dataset['categories'] = copy.deepcopy(self.dataset['categories'])
         for id, ann in enumerate(anns):
+            ann['bbox'] = ann['bbox'][0]
             bb = ann['bbox']
             x1, x2, y1, y2 = [bb[0], bb[0] + bb[2], bb[1], bb[1] + bb[3]]
             if 'segmentation' not in ann:

--- a/train.py
+++ b/train.py
@@ -490,7 +490,7 @@ def evaluate(model, data_loader, cfg, device, logger=None, **kwargs):
         # outputs = outputs.cpu().detach().numpy()
         res = {}
         # for img, target, output in zip(images, targets, outputs):
-        for img, target, (boxes, confs) in zip(images, targets, outputs):
+        for img, target, boxes, confs in zip(images, targets, outputs[0], outputs[1]):
             img_height, img_width = img.shape[:2]
             # boxes = output[...,:4].copy()  # output boxes in yolo format
             boxes = boxes.squeeze(2).cpu().detach().numpy()


### PR DESCRIPTION
Debug finds that two parameters for the function COCOeval.evaluate():Coco_gt and COCO_dt should both be instances of COCO classes,so they should have the same data structure,but per "bbox" value of coco_gt.dataset.annotations (generated by convert_to_coco_api function) and coco_dt.dataset.annotations (generated by coco_eval.py /loadRes function) are different,one is a list:[X,Y, H, W], and the other is a nested list:[[X,Y, H, W]].