### PR TITLE
create usable get_image_id function

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -423,11 +423,18 @@ def get_image_id(filename:str) -> int:
     >>> no = f"{int(no):04d}"
     >>> return int(lv+no)
     """
-    raise NotImplementedError("Create your own 'get_image_id' function")
-    lv, no = os.path.splitext(os.path.basename(filename))[0].split("_")
-    lv = lv.replace("level", "")
-    no = f"{int(no):04d}"
-    return int(lv+no)
+    # raise NotImplementedError("Create your own 'get_image_id' function")
+    # lv, no = os.path.splitext(os.path.basename(filename))[0].split("_")
+    # lv = lv.replace("level", "")
+    # no = f"{int(no):04d}"
+    # return int(lv+no)
+
+    print("You could also create your own 'get_image_id' function.")
+    # print(filename)
+    parts = filename.split('/')
+    id = int(parts[-1][0:-4])
+    # print(id)
+    return id
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The original 'get_image_id' function does nothing but raises an error, which interrupts the training stage. 
That's why I create a new 'get_image_id' function, which applies the img name as id.
I also print a notice that "You could also create your own 'get_image_id' function".