### PR TITLE
Fix typo skimage to scikit-image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ matplotlib==2.2.3
 tqdm==4.43.0
 easydict==1.9
 Pillow==7.1.2
-skimage
+scikit-image
 opencv_python
 pycocotools


### PR DESCRIPTION
Hi! Fixed skimage was invalid name.
regards.