### PR TITLE
fix typo of mosaic augmentation name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A minimal PyTorch implementation of YOLOv4.
 
 - [x] Inference
 - [x] Train
-    - [x] Mocaic
+    - [x] Mosaic
 
 ```
 ├── README.md


### PR DESCRIPTION
Hello, thank you all for your work on this project. This is my first contribution to any open source project. Although this is a very simple fix, I am hoping that this will be merged. 


In the README.md file, there is a typo in the **Mosaic** augmentation name. I fixed that typo in this pull request. 