### PR TITLE
support for custom darknet model conversion to onnx

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Until now, still a small piece of post-processing including NMS is required. We 
 - **Run python script to generate ONNX model and run the demo**
 
     ```sh
-    python demo_darknet2onnx.py <cfgFile> <weightFile> <imageFile> <batchSize>
+    python demo_darknet2onnx.py <cfgFile> <namesFile> <weightFile> <imageFile> <batchSize>
     ```
 
 ## 3.1 Dynamic or static batch size

--- a/demo_darknet2onnx.py
+++ b/demo_darknet2onnx.py
@@ -10,7 +10,7 @@ from tool.utils import *
 from tool.darknet2onnx import *
 
 
-def main(cfg_file, weight_file, image_path, batch_size):
+def main(cfg_file, namesfile, weight_file, image_path, batch_size):
 
     if batch_size <= 0:
         onnx_path_demo = transform_to_onnx(cfg_file, weight_file, batch_size)
@@ -25,11 +25,11 @@ def main(cfg_file, weight_file, image_path, batch_size):
     print("The model expects input shape: ", session.get_inputs()[0].shape)
 
     image_src = cv2.imread(image_path)
-    detect(session, image_src)
+    detect(session, image_src, namesfile)
 
 
 
-def detect(session, image_src):
+def detect(session, image_src, namesfile):
     IN_IMAGE_H = session.get_inputs()[0].shape[2]
     IN_IMAGE_W = session.get_inputs()[0].shape[3]
 
@@ -48,14 +48,6 @@ def detect(session, image_src):
 
     boxes = post_processing(img_in, 0.4, 0.6, outputs)
 
-    num_classes = 80
-    if num_classes == 20:
-        namesfile = 'data/voc.names'
-    elif num_classes == 80:
-        namesfile = 'data/coco.names'
-    else:
-        namesfile = 'data/names'
-
     class_names = load_class_names(namesfile)
     plot_boxes_cv2(image_src, boxes[0], savename='predictions_onnx.jpg', class_names=class_names)
 
@@ -63,12 +55,13 @@ def detect(session, image_src):
 
 if __name__ == '__main__':
     print("Converting to onnx and running demo ...")
-    if len(sys.argv) == 5:
+    if len(sys.argv) == 6:
         cfg_file = sys.argv[1]
-        weight_file = sys.argv[2]
-        image_path = sys.argv[3]
-        batch_size = int(sys.argv[4])
-        main(cfg_file, weight_file, image_path, batch_size)
+        namesfile = sys.argv[2]
+        weight_file = sys.argv[3]
+        image_path = sys.argv[4]
+        batch_size = int(sys.argv[5])
+        main(cfg_file, namesfile, weight_file, image_path, batch_size)
     else:
         print('Please run this way:\n')
-        print('  python demo_onnx.py <cfgFile> <weightFile> <imageFile> <batchSize>')
+        print('  python demo_onnx.py <cfgFile> <namesFile> <weightFile> <imageFile> <batchSize>')


### PR DESCRIPTION
The current demo_darknet2onnx.py converts the darknet model trained on coco dataset by default. 

To convert any custom model, we have to edit the source code and put the number of class by hand.

I modified the demo_darknet2onnx.py file to take the names file of darknet as input and convert that model to onnx format. In this way, this script can be used to convert any model.

I also updated the README.md file according to these changes.  