### PR TITLE
Skip connections where not connected, discrepancy in scores.

### DIFF
--- a/tool/darknet2pytorch.py
+++ b/tool/darknet2pytorch.py
@@ -264,8 +264,10 @@ class Darknet(nn.Module):
                     model.add_module('relu{0}'.format(conv_id), nn.ReLU(inplace=True))
                 elif activation == 'mish':
                     model.add_module('mish{0}'.format(conv_id), Mish())
+                elif activation == 'linear':
+                    model.add_module("linear{0}".format(conv_id), nn.Identity())
                 else:
-                    print("convalution havn't activate {}".format(activation))
+                    print("convalution haven't activate {}".format(activation))
 
                 prev_filters = filters
                 out_filters.append(prev_filters)


### PR DESCRIPTION
Skip connections were 'dangling' which resulted in onnx/pytorch model haveing worse performance after conversion.
Darknet uses name "Linear", but it's translates to "Identity" in PyTorch.