### PR TITLE
fix: Fix param minShapes for trtexec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ python demo_trt.py <tensorRT_engine_file> <input_image> <input_H> <input_W>
    
    For multi-batch, 
   ```
-  trtexec --onnx=<onnx_file> --explicitBatch --shapes=input:Xx3xHxW --optShapes=input:Xx3xHxW --maxShapes=input:Xx3xHxW --minShape=input:1x3xHxW --saveEngine=<tensorRT_engine_file> --fp16
+  trtexec --onnx=<onnx_file> --explicitBatch --shapes=input:Xx3xHxW --optShapes=input:Xx3xHxW --maxShapes=input:Xx3xHxW --minShapes=input:1x3xHxW --saveEngine=<tensorRT_engine_file> --fp16
   ```
   
   Note :The maxShapes could not be larger than model original shape.


### PR DESCRIPTION
It should be `minShapes`, not `minShape`

```
  --minShapes=spec            Build with dynamic shapes using a profile with the min shapes provided
  --optShapes=spec            Build with dynamic shapes using a profile with the opt shapes provided
  --maxShapes=spec            Build with dynamic shapes using a profile with the max shapes provided
```