### PR TITLE
Improved CLI arguments

### DIFF
--- a/cfg/example_cfg.yaml
+++ b/cfg/example_cfg.yaml
@@ -1,18 +1,6 @@
-# -*- coding: utf-8 -*-
-'''
-@Time          : 2022/03/03
-@Author        : Kevin Kastberg
-@File          : example_cfg.yaml
-@Noice         :
-@Modificattion :
-    @Author    :
-    @Time      :
-    @Detail    :
-
-'''
 
 use_darknet_cfg: true
-cfgfile: "cfg/yolov4.cfg"
+cfgfile: 'cfg/yolov4.cfg'
 
 batch: 64
 subdivisions: 16

--- a/cfg/example_cfg.yaml
+++ b/cfg/example_cfg.yaml
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+'''
+@Time          : 2022/03/03
+@Author        : Kevin Kastberg
+@File          : example_cfg.yaml
+@Noice         :
+@Modificattion :
+    @Author    :
+    @Time      :
+    @Detail    :
+
+'''
+
+use_darknet_cfg: true
+cfgfile: "cfg/yolov4.cfg"
+
+batch: 64
+subdivisions: 16
+width: &width 608
+height: &height 608
+channels: 3
+momentum: 0.949
+decay: 0.0005
+angle: 0
+saturation: 1.5
+exposure: 1.5
+hue: .1
+
+learning_rate: 0.00261
+burn_in: 1000
+max_batches: 500500
+steps: &steps [400000, 450000]
+policy: *steps
+scales: .1, .1
+
+cutmix: 0
+mosaic: 1
+mixup: 3
+
+letter_box: 0
+jitter: 0.2
+classes: 80
+track: 0
+w: *width
+h: *height
+flip: 1
+blur: 0
+gaussian: 0
+boxes: 60
+TRAIN_EPOCHS: 300
+train_label: 'train.txt'
+val_label: 'val.txt'
+TRAIN_OPTIMIZER: 'adam'
+
+checkpoints: 'checkpoints'
+TRAIN_TENSORBOARD_DIR: 'log'
+iou_type: 'iou'
+keep_checkpoint_max: 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ easydict==1.9
 Pillow==7.1.2
 opencv_python
 pycocotools
+pyyaml

--- a/train.py
+++ b/train.py
@@ -536,6 +536,8 @@ def get_args(**kwargs):
         description='This script trains the YoloV4 model on images with object masks. '
         'Command line arguments that are not specified retrives default values from the config file.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-dir', '--data-dir', type=str, dest='dataset_dir',
+                        help='Path to dataset (base_dir for paths in train.txt/val.txt)')
     parser.add_argument('-b', '--batch-size', type=int, dest='batchsize',
                         help='Batch size', metavar='B')
     parser.add_argument('-l', '--learning-rate', type=float, dest='learning_rate',
@@ -545,8 +547,6 @@ def get_args(**kwargs):
     parser.add_argument('-g', '--gpu', type=str, dest='gpu',
                         help='GPU ID (If not specified CPU will be used)',
                         metavar='G', default='-1')
-    parser.add_argument('-dir', '--data-dir', type=str, dest='dataset_dir',
-                        help='Path to dataset (base_dir for paths in train.txt/val.txt)')
     parser.add_argument('-pretrained', type=str, dest='pretrained',
                         help='Load pretrained weights (yolov4.conv.137)')
     parser.add_argument('-classes', type=int, dest='classes',
@@ -576,8 +576,13 @@ def get_args(**kwargs):
             file_args = yaml.load(f, Loader=yaml.FullLoader)
     else:
         file_args = cfg
-
     file_args.update(cli_args)
+
+    # Check if required args are set
+    assert {"dataset_dir", "batchsize", "learning_rate", "classes",
+            "train_label", "val_label", "TRAIN_OPTIMIZER", "iou_type",
+            "keep_checkpoint_max"} <= set(file_args.keys())
+
     return edict(file_args)
 
 

--- a/train.py
+++ b/train.py
@@ -535,21 +535,37 @@ def get_args(**kwargs):
         description='This script trains the YoloV4 model on images with object masks. '
         'Command line arguments that are not specified retrives default values from the config file.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-b', '--batch-size',     type=int,   dest='batchsize',     help='Batch size', metavar='B')
-    parser.add_argument('-l', '--learning-rate',  type=float, dest='learning_rate', help='Learning rate', metavar='LR')
-    parser.add_argument('-f', '--load',           type=str,   dest='load',          help='Load model from a .pth file')
-    parser.add_argument('-g', '--gpu',            type=str,   dest='gpu',                   help='GPU ID (If not specified CPU will be used)',  metavar='G', default='-1')
-    parser.add_argument('-dir', '--data-dir',     type=str,   dest='dataset_dir',   help='Path to dataset (base_dir for paths in train.txt/val.txt)')
-    parser.add_argument('-pretrained',            type=str,   dest='pretrained',    help='Load pretrained weights (yolov4.conv.137)')
-    parser.add_argument('-classes',               type=int,   dest='classes',       help='Count of dataset classes')
-    parser.add_argument('-train_label_path',      type=str,   dest='train_label',     help='Path to train.txt')
-    parser.add_argument('-val_label_path',        type=str,   dest='val_label',       help='Path to val.txt')
-    parser.add_argument('-optimizer',             type=str,   dest='TRAIN_OPTIMIZER', help='Training optimizer')
-    parser.add_argument('-iou-type',              type=str,   dest='iou_type',        help='iou type [iou, giou, diou, ciou]')
-    parser.add_argument('-keep-checkpoint-max',   type=int,   dest='keep_checkpoint_max', help='Maximum number of checkpoints to keep (set to 0 to save all)')
-    parser.add_argument('-log_path',              type=str,   dest='TRAIN_TENSORBOARD_DIR', help='Path to training progress log files')
-    parser.add_argument('-checkpoint_path',       type=str,   dest='checkpoints',           help='Path to checkpoint files')
-    parser.add_argument('-config',                type=str,   dest='config_path',           help='Path to custom yaml config file (overrides cfg.py)')
+    parser.add_argument('-b', '--batch-size', type=int, dest='batchsize',
+                        help='Batch size', metavar='B')
+    parser.add_argument('-l', '--learning-rate', type=float, dest='learning_rate',
+                        help='Learning rate', metavar='LR')
+    parser.add_argument('-f', '--load', type=str, dest='load',
+                        help='Load model from a .pth file')
+    parser.add_argument('-g', '--gpu', type=str, dest='gpu',
+                        help='GPU ID (If not specified CPU will be used)',
+                        metavar='G', default='-1')
+    parser.add_argument('-dir', '--data-dir', type=str, dest='dataset_dir',
+                        help='Path to dataset (base_dir for paths in train.txt/val.txt)')
+    parser.add_argument('-pretrained', type=str, dest='pretrained',
+                        help='Load pretrained weights (yolov4.conv.137)')
+    parser.add_argument('-classes', type=int, dest='classes',
+                        help='Count of dataset classes')
+    parser.add_argument('-train_label_path', type=str, dest='train_label',
+                        help='Path to train.txt')
+    parser.add_argument('-val_label_path', type=str, dest='val_label',
+                        help='Path to val.txt')
+    parser.add_argument('-optimizer', type=str, dest='TRAIN_OPTIMIZER',
+                        help='Training optimizer')
+    parser.add_argument('-iou-type', type=str, dest='iou_type',
+                        help='iou type [iou, giou, diou, ciou]')
+    parser.add_argument('-keep-checkpoint-max', type=int, dest='keep_checkpoint_max',
+                        help='Maximum number of checkpoints to keep (set to 0 to save all)')
+    parser.add_argument('-log_path', type=str, dest='TRAIN_TENSORBOARD_DIR',
+                        help='Path to training progress log files')
+    parser.add_argument('-checkpoint_path', type=str, dest='checkpoints',
+                        help='Path to checkpoint files')
+    parser.add_argument('-config', type=str, dest='config_path',
+                        help='Path to custom yaml config file (overrides cfg.py)')
     args = vars(parser.parse_args())
 
     cfg.update(args)

--- a/train.py
+++ b/train.py
@@ -529,40 +529,30 @@ def evaluate(model, data_loader, cfg, device, logger=None, **kwargs):
 
 
 def get_args(**kwargs):
+    """Parse args from command line and CFG-file"""
     cfg = kwargs
-    parser = argparse.ArgumentParser(description='Train the Model on images and target masks',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    # parser.add_argument('-b', '--batch-size', metavar='B', type=int, nargs='?', default=2,
-    #                     help='Batch size', dest='batchsize')
-    parser.add_argument('-l', '--learning-rate', metavar='LR', type=float, nargs='?', default=0.001,
-                        help='Learning rate', dest='learning_rate')
-    parser.add_argument('-f', '--load', dest='load', type=str, default=None,
-                        help='Load model from a .pth file')
-    parser.add_argument('-g', '--gpu', metavar='G', type=str, default='-1',
-                        help='GPU', dest='gpu')
-    parser.add_argument('-dir', '--data-dir', type=str, default=None,
-                        help='dataset dir', dest='dataset_dir')
-    parser.add_argument('-pretrained', type=str, default=None, help='pretrained yolov4.conv.137')
-    parser.add_argument('-classes', type=int, default=80, help='dataset classes')
-    parser.add_argument('-train_label_path', dest='train_label', type=str, default='train.txt', help="train label path")
-    parser.add_argument(
-        '-optimizer', type=str, default='adam',
-        help='training optimizer',
-        dest='TRAIN_OPTIMIZER')
-    parser.add_argument(
-        '-iou-type', type=str, default='iou',
-        help='iou type (iou, giou, diou, ciou)',
-        dest='iou_type')
-    parser.add_argument(
-        '-keep-checkpoint-max', type=int, default=10,
-        help='maximum number of checkpoints to keep. If set 0, all checkpoints will be kept',
-        dest='keep_checkpoint_max')
+    parser = argparse.ArgumentParser(
+        description='This script trains the YoloV4 model on images with object masks. '
+        'Command line arguments that are not specified retrives default values from the config file.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-b', '--batch-size',     type=int,   dest='batchsize',     help='Batch size', metavar='B')
+    parser.add_argument('-l', '--learning-rate',  type=float, dest='learning_rate', help='Learning rate', metavar='LR')
+    parser.add_argument('-f', '--load',           type=str,   dest='load',          help='Load model from a .pth file')
+    parser.add_argument('-g', '--gpu',            type=str,   dest='gpu',                   help='GPU ID (If not specified CPU will be used)',  metavar='G', default='-1')
+    parser.add_argument('-dir', '--data-dir',     type=str,   dest='dataset_dir',   help='Path to dataset (base_dir for paths in train.txt/val.txt)')
+    parser.add_argument('-pretrained',            type=str,   dest='pretrained',    help='Load pretrained weights (yolov4.conv.137)')
+    parser.add_argument('-classes',               type=int,   dest='classes',       help='Count of dataset classes')
+    parser.add_argument('-train_label_path',      type=str,   dest='train_label',     help='Path to train.txt')
+    parser.add_argument('-val_label_path',        type=str,   dest='val_label',       help='Path to val.txt')
+    parser.add_argument('-optimizer',             type=str,   dest='TRAIN_OPTIMIZER', help='Training optimizer')
+    parser.add_argument('-iou-type',              type=str,   dest='iou_type',        help='iou type [iou, giou, diou, ciou]')
+    parser.add_argument('-keep-checkpoint-max',   type=int,   dest='keep_checkpoint_max', help='Maximum number of checkpoints to keep (set to 0 to save all)')
+    parser.add_argument('-log_path',              type=str,   dest='TRAIN_TENSORBOARD_DIR', help='Path to training progress log files')
+    parser.add_argument('-checkpoint_path',       type=str,   dest='checkpoints',           help='Path to checkpoint files')
+    parser.add_argument('-config',                type=str,   dest='config_path',           help='Path to custom yaml config file (overrides cfg.py)')
     args = vars(parser.parse_args())
 
-    # for k in args.keys():
-    #     cfg[k] = args.get(k)
     cfg.update(args)
-
     return edict(cfg)
 
 

--- a/train.py
+++ b/train.py
@@ -581,8 +581,8 @@ def get_args(**kwargs):
     # Check if required args are set
     assert {"dataset_dir", "batchsize", "learning_rate", "classes",
             "train_label", "val_label", "TRAIN_OPTIMIZER", "iou_type",
-            "keep_checkpoint_max"} <= set(file_args.keys())
-
+            "keep_checkpoint_max"} <= set(file_args.keys()),\
+            "Required config args are missing"
     return edict(file_args)
 
 

--- a/train.py
+++ b/train.py
@@ -538,7 +538,7 @@ def get_args(**kwargs):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-dir', '--data-dir', type=str, dest='dataset_dir',
                         help='Path to dataset (base_dir for paths in train.txt/val.txt)')
-    parser.add_argument('-b', '--batch-size', type=int, dest='batchsize',
+    parser.add_argument('-b', '--batch-size', type=int, dest='batch',
                         help='Batch size', metavar='B')
     parser.add_argument('-l', '--learning-rate', type=float, dest='learning_rate',
                         help='Learning rate', metavar='LR')
@@ -579,7 +579,7 @@ def get_args(**kwargs):
     file_args.update(cli_args)
 
     # Check if required args are set
-    assert {"dataset_dir", "batchsize", "learning_rate", "classes",
+    assert {"dataset_dir", "batch", "learning_rate", "classes",
             "train_label", "val_label", "TRAIN_OPTIMIZER", "iou_type",
             "keep_checkpoint_max"} <= set(file_args.keys()),\
             "Required config args are missing"

--- a/train.py
+++ b/train.py
@@ -16,6 +16,7 @@ import os, sys, math
 import argparse
 from collections import deque
 import datetime
+import yaml
 
 import cv2
 from tqdm import tqdm
@@ -566,10 +567,18 @@ def get_args(**kwargs):
                         help='Path to checkpoint files')
     parser.add_argument('-config', type=str, dest='config_path',
                         help='Path to custom yaml config file (overrides cfg.py)')
-    args = vars(parser.parse_args())
+    cli_args_with_nan = vars(parser.parse_args())
+    cli_args = {key:val for key,val in cli_args_with_nan.items() if val is not None}
 
-    cfg.update(args)
-    return edict(cfg)
+    # Load remaining args from config file
+    if cli_args.get("config_path"):
+        with open(cli_args["config_path"], "r") as f:
+            file_args = yaml.load(f, Loader=yaml.FullLoader)
+    else:
+        file_args = cfg
+
+    file_args.update(cli_args)
+    return edict(file_args)
 
 
 def init_logger(log_file=None, log_dir=None, log_level=logging.INFO, mode='w', stdout=True):


### PR DESCRIPTION
This PR improves the CLI interface by making the default values for the CLI arguments to be retrieved from the config file and adding the following CLI arguments:  
- batch_size: Batch size for training
- val_path: Path to val.txt
- log_path: Path to store tensorbordX log files
- checkpoint_path: Path to store checkpoints
- config: Path to a custom yaml config file that overrides cfg.py

The benefit of this PR is that training from CLI is simpler and more versatile. The optional possibility to pass in a custom yaml config file from the command line also makes it great for remote deployment.

I hope you see the benefit and believe it is an improvement. Please contact me with any questions and feel free to edit the code.