### PR TITLE
Bugfix: do_detect gets 4 or 5 arg, but receives 6

### DIFF
--- a/evaluate_on_coco.py
+++ b/evaluate_on_coco.py
@@ -172,7 +172,7 @@ def test(model, annotations, cfg):
 
     # do one forward pass first to circumvent cold start
     throwaway_image = Image.open('data/dog.jpg').convert('RGB').resize((model.width, model.height))
-    do_detect(model, throwaway_image, 0.5, 80, 0.4, use_cuda)
+    do_detect(model, throwaway_image, 0.5, 0.4, use_cuda)
     boxes_json = []
 
     for i, image_annotation in enumerate(images):
@@ -190,7 +190,7 @@ def test(model, annotations, cfg):
             model.cuda()
 
         start = time.time()
-        boxes = do_detect(model, sized, 0.0, 80, 0.4, use_cuda)
+        boxes = do_detect(model, sized, 0.0, 0.4, use_cuda)
         finish = time.time()
         if type(boxes) == list:
             for box in boxes:


### PR DESCRIPTION
do_detect() has an extra argument. Comparing to previous version used to be
    boxes = do_detect(model, sized, 0.0, 0.4, use_cuda)
but now it is
    boxes = do_detect(model, sized, 0.0, 80, 0.4, use_cuda)
Is this a typo? do_detect() wasn't changed to accommodate an extra argument.